### PR TITLE
Improve flexibility and composeability of workflow components

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -10,7 +10,7 @@
 conda.enabled = true
 
 // Import profile settings
-includeConfig "${projectDir}/conf/profiles.config"
+includeConfig "conf/profiles.config"
 
 // Global default params
 params {

--- a/subworkflows/alignData/main.nf
+++ b/subworkflows/alignData/main.nf
@@ -22,6 +22,15 @@ isolate_data_file = file("${output_directory}/Isolate_Data.tsv")
 snpdiffs_summary_file = file("${output_directory}/Raw_MUMmer_Summary.tsv")
 mummerScript = file("$projectDir/bin/compileMUMmer.py")
 
+workflow {
+    main:
+    // Align genomes
+    snpdiffs = alignGenomes(to_align: read_data, snpdiffs_data: snpdiffs_data)
+    publish:
+    // Publish snpdiffs
+    snpdiffs >> 'snpdiffs.tsv'
+}
+
 workflow alignGenomes{
     take:
     to_align

--- a/subworkflows/fetchData/main.nf
+++ b/subworkflows/fetchData/main.nf
@@ -22,6 +22,16 @@ userSNPDiffs = file("${projectDir}/bin/userSNPDiffs.py")
 // Set SKESA cores to 5 or fewer
 skesa_cpus = (params.cores as Integer) >= 5 ? 5 : (params.cores as Integer)
 
+workflow {
+    main:
+    query_data, reference_data, snpdiff_data = fetchData()
+
+    publish:
+    query_data >> 'query_data.tsv'
+    reference_data >> 'reference_data.tsv'
+    snpdiff_data >> 'snpdiff_data.tsv'
+}
+
 // Top-level workflow //
 workflow fetchData{
 

--- a/subworkflows/refchooser/main.nf
+++ b/subworkflows/refchooser/main.nf
@@ -5,6 +5,15 @@ output_directory = file(params.output_directory)
 log_directory = file(params.log_directory)
 mash_directory = file(params.mash_directory)
 
+workflow {
+    main:
+    // Run RefChooser
+    reference_data = runRefChooser(query_data: query_data)
+    publish:
+    // Publish reference data
+    reference_data >> 'reference.fa'
+}
+
 workflow runRefChooser{
     take:
     query_data

--- a/subworkflows/snpdiffs/main.nf
+++ b/subworkflows/snpdiffs/main.nf
@@ -33,6 +33,12 @@ query_edge = params.query_edge.toInteger()
 max_missing = params.max_missing.toFloat()
 n_ref = params.n_ref.toInteger()
 
+workflow {
+    main:
+    // Run SNP pipeline
+    runSNPPipeline(query_data: all_snpdiffs, reference_data: ref_id_file)
+}
+
 workflow runScreen {
     
     take:


### PR DESCRIPTION
It would be good for Galaxy if we had finer-grained control over components of the workflow from outside the main workflow, so components could be used in isolation alongside Galaxy as a task orchestrator.

These commits improve the composeability of CSP2 subworkflows by correcting an absolute path in the nextflow.config profile and by adding simple entry workflows to `subworkflows/*.nf` . Untested currently.