### PR TITLE
Galaxy-targeted build of the CSP2 container, auto-built on release

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,3 +32,15 @@ jobs:
             CSP2_BRANCH=${{ github.ref_name }}
           push: true
           tags: cfsanbiostatistics/csp2:latest,cfsanbiostatistics/csp2:${{ github.ref_name }}
+      -
+        name: Build for Galaxy
+        uses: docker/build-push-action@v6
+        with:
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          target: galaxy
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            CSP2_BRANCH=${{ github.ref_name }}
+          push: true
+          tags: cfsanbiostatistics/csp2:galaxy,cfsanbiostatistics/csp2:${{ github.ref_name }}-galaxy

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -164,12 +164,10 @@ ENV PATH="/opt/venv/bin:/usr/local/bin:/skesa:$PATH" \
     LC_ALL=C \
     NXF_OFFLINE='true'
 
-ADD bin ./bin
-ADD conf ./conf
-ADD subworkflows ./subworkflows
-ADD CSP2.nf ./CSP2.nf
-ADD nextflow.config ./nextflow.config
 
+
+# Add the CSP2 pipeline, these are the parts that change most often in a release
+ADD bin/ conf/ subworkflows/ CSP2.nf nextflow.config ./
 
 FROM app AS pretest
 
@@ -221,6 +219,31 @@ RUN awk '{print $1 "\t" $2 "\t" $3 "\t" $4 "\t" $5 "\t" $6}' V5.3.2.artic.bed > 
 
 RUN /bin/bash -c 'make test'
 
+FROM app AS galaxy
+
+ARG CSP2_VER
+ARG BEDTOOLS_VER
+ARG MUMMER_VER
+ARG SKESA_VER
+ARG MASH_VER
+ARG BBMAP_VER
+ARG PYTHON_VER
+ENV CSP2_VER=${CSP2_VER}
+ENV BEDTOOLS_VER=${BEDTOOLS_VER}
+ENV MUMMER_VER=${MUMMER_VER}
+ENV SKESA_VER=${SKESA_VER}
+ENV MASH_VER=${MASH_VER}
+ENV BBMAP_VER=${BBMAP_VER}
+ENV PYTHON_VER=${PYTHON_VER}
+
+# set PATH, set perl locale settings for singularity compatibility
+ENV PATH="/opt/venv/bin:/usr/local/bin:/skesa:$PATH" \
+    LC_ALL=C \
+    NXF_OFFLINE='true'
+
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["/bin/bash"]
+
 FROM app AS release
 
 ARG CSP2_VER
@@ -244,3 +267,4 @@ ENV PATH="/opt/venv/bin:/usr/local/bin:/skesa:$PATH" \
     NXF_OFFLINE='true'
 
 ENTRYPOINT ["make", "--makefile=/app/Makefile"]
+


### PR DESCRIPTION
Small change to Dockerfile and associated Github action to create a "galaxy" tagged build of the container; this build sets bash as the entrypoint.

A "pre-release" version of the container is available at

https://hub.docker.com/repository/docker/cfsanbiostatistics/csp2/tags/v.0.9.0-199-gc474db7-galaxy/sha256-bd001191874fee0c0c5f6a37d474037a97057c454de642df7c1d385ad4831e1b